### PR TITLE
fix rss

### DIFF
--- a/src/Config/RoutingAndMvc.cs
+++ b/src/Config/RoutingAndMvc.cs
@@ -40,11 +40,7 @@ namespace Microsoft.AspNetCore.Builder
             bool sslIsAvailable
             )
         {
-            services.Configure<ForwardedHeadersOptions>(options =>
-            {
-                options.ForwardedHeaders = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto;
-            });
-
+            
             services.Configure<MvcOptions>(options =>
             {
                 if (sslIsAvailable)

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -179,7 +179,7 @@ namespace DotNetFoundationWebsite
                 app.UseHsts();
             }
 
-            app.UseForwardedHeaders();
+            
             app.UseHttpsRedirection();
             app.UseStaticFiles();
             app.UseCloudscribeCommonStaticFiles();

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -182,6 +182,7 @@ namespace DotNetFoundationWebsite
             app.UseForwardedHeaders();
             app.UseHttpsRedirection();
             app.UseStaticFiles();
+            app.UseCloudscribeCommonStaticFiles();
             app.UseCookiePolicy();
             //app.UseSession();
 

--- a/src/Views/Shared/Components/Navigation/BootstrapTopNavWithDropdowns.cshtml
+++ b/src/Views/Shared/Components/Navigation/BootstrapTopNavWithDropdowns.cshtml
@@ -14,19 +14,19 @@
             {
                 <li role="presentation" class='@Model.GetClass(node.Value)' cwn-data-attributes="@node.Value.DataAttributes"><a href="@Url.Content(Model.AdjustUrl(node))">@Html.Raw(Model.GetIcon(node.Value))@Model.AdjustText(node)</a></li>
             }
-            else if(!node.Value.IsClickable)
+            else if (!node.Value.IsClickable)
             {
 
                 <li role="presentation" class='@Model.GetClass(node.Value, "dropdown")' cwn-data-attributes="@node.Value.DataAttributes">  
                     <a href="javascript:void(0);" class="dropdown-toggle" data-toggle="dropdown" data-hover="dropdown">@Model.AdjustText(node)</a>
-                    @Model.UpdateTempNode(node)@Html.Partial("NavNodeChildDropdownAnimatedPartial", Model)
+                    @Model.UpdateTempNode(node)@{ await Html.PartialAsync("NavNodeChildDropdownAnimatedPartial", Model); }
                 </li>
             }
             else
             {
                 <li role="presentation" class='@Model.GetClass(node.Value, "dropdown")' cwn-data-attributes="@node.Value.DataAttributes">
                     <a href="@Url.Content(Model.AdjustUrl(node))">@Html.Raw(Model.GetIcon(node.Value))@Model.AdjustText(node) <span class="caret"></span></a>
-                    @Model.UpdateTempNode(node)@Html.Partial("NavigationNodeChildDropdownPartial", Model)
+                    @Model.UpdateTempNode(node)@{await Html.PartialAsync("NavigationNodeChildDropdownPartial", Model); }
                 </li>
             }
         }

--- a/src/Views/Shared/NavNodeChildDropdownAnimatedPartial.cshtml
+++ b/src/Views/Shared/NavNodeChildDropdownAnimatedPartial.cshtml
@@ -11,7 +11,7 @@
         if (childNode.Value.Text == "Separator")
         {
             <li class="divider"></li>
-                continue;
+            continue;
         }
         if (!Model.HasVisibleChildren(childNode))
         {
@@ -21,7 +21,7 @@
         {
             <li role="presentation" class='@Model.GetClass(childNode.Value, "dropdown-submenu")' cwn-data-attributes="@childNode.Value.DataAttributes">
                 <a href="@Url.Content(Model.AdjustUrl(childNode))">@Html.Raw(Model.GetIcon(childNode.Value))@Model.AdjustText(childNode) <span class="caret"></span></a>
-                @Model.UpdateTempNode(childNode)@Html.Partial("NavigationNodeChildDropdownPartial", Model) @* recursion *@
+                @Model.UpdateTempNode(childNode)@{ await Html.PartialAsync("NavigationNodeChildDropdownPartial", Model); } @* recursion *@
             </li>
         }
     }

--- a/src/Views/Shared/NavigationNodeChildDropdownPartial.cshtml
+++ b/src/Views/Shared/NavigationNodeChildDropdownPartial.cshtml
@@ -11,7 +11,7 @@
         if (childNode.Value.Text == "Separator")
         {
             <li class="divider"></li>
-                continue;
+            continue;
         }
         if (!Model.HasVisibleChildren(childNode))
         {
@@ -21,7 +21,7 @@
         {
             <li role="presentation" class='@Model.GetClass(childNode.Value, "dropdown-submenu")' cwn-data-attributes="@childNode.Value.DataAttributes">
                 <a href="@Url.Content(Model.AdjustUrl(childNode))">@Html.Raw(Model.GetIcon(childNode.Value))@Model.AdjustText(childNode) <span class="caret"></span></a>
-                @Model.UpdateTempNode(childNode)@Html.Partial("NavigationNodeChildDropdownPartial", Model) @* recursion *@
+                @Model.UpdateTempNode(childNode)@{ await Html.PartialAsync("NavigationNodeChildDropdownPartial", Model); } @* recursion *@
             </li>
         }
     }

--- a/src/dotnetfoundation-website.csproj
+++ b/src/dotnetfoundation-website.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -32,10 +32,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="cloudscribe.Web.StaticFiles" Version="1.0.5" />
     <PackageReference Include="cloudscribe.Core.Web" Version="3.1.19" />
     <PackageReference Include="cloudscribe.Core.CompiledViews.Bootstrap3" Version="3.1.10" />
     <PackageReference Include="cloudscribe.Core.Storage.EFCore.MSSQL" Version="3.0.5" />
-    <PackageReference Include="cloudscribe.Core.SimpleContent" Version="4.0.0" />
+    <PackageReference Include="cloudscribe.Core.SimpleContent" Version="4.0.1" />
     <PackageReference Include="cloudscribe.SimpleContent.Web" Version="4.0.10" />
     <PackageReference Include="cloudscribe.Core.SimpleContent.CompiledViews.Bootstrap3" Version="4.0.0" />
     <PackageReference Include="cloudscribe.SimpleContent.CompiledViews.Bootstrap3" Version="4.0.6" />


### PR DESCRIPTION
Hi Jon,

This turned out to be a bug which I've fixed upstream and updated the nuget for cloudscribe.Core.SimpleContent which is the integration library between cloudscribe core and cloudscribe simplecontent. The viewmodel for content settings had been updated with new fields for DefaultFeedItems and MaxFeedItems, but when saving settings it was not updating those and the viewmodel wasn't being populated from the underlying settings. The ViewModel had defaults of 20 and 1000 so it looked like they were populated but really they were both 0 in the db in cs_ContentProject table. I should have added defaults for those in the dbcontext when I added those fields, without them existing sites just got 0 for the defaults and the bug in the edit page kept them from being updated.
After you deploy the update you will need to go to Administration > Content Settings and change the 0s to what you want ie 20, and 1000, and that will solve it.
Note that you can pass a parameter to get more items than the default but limited by the maxitems setting.
/api/rss?maxItems=100 for example

Sorry about the bug!
