### PR TITLE
Fix Font Awesome Twitter Icons

### DIFF
--- a/src/Pages/About.cshtml
+++ b/src/Pages/About.cshtml
@@ -357,7 +357,7 @@
                             <img class="rounded-image" alt="ProfilePicture" src="https://dnfwebsitewusproduction.blob.core.windows.net/media/Default/_Profiles/a3cd3d28/d0c44402/jon-galloway.png?v=636235777890000000">
                             <h4 class="col-md-3-name">Jon Galloway</h4>
                             <span>
-                                <a href="https://twitter.com/jongalloway"><i class="fa fa-twitter" aria-hidden="true"></i></a>
+                                <a href="https://twitter.com/jongalloway"><i class="fab fa-twitter" aria-hidden="true"></i></a>
                             </span>
                             <div class="col-md-3-body">
                                 I'm <strong>Jon Galloway</strong>, Executive Director of the .NET Foundation. I work closely with the board, advisory council, lawyers
@@ -369,7 +369,7 @@
                             <img class="rounded-image" alt="ProfilePicture" src="https://dnfwebsitewusproduction.blob.core.windows.net/media/Default/_Profiles/a3cd3d28/d0c44402/RobinG.JPG?v=636122643340000000">
                             <h4 class="col-md-3-name">Robin Ginn</h4>
                             <span>
-                                <a href="https://twitter.com/rginn206"><i class="fa fa-twitter" aria-hidden="true"></i></a>
+                                <a href="https://twitter.com/rginn206"><i class="fab fa-twitter" aria-hidden="true"></i></a>
                             </span>
                             <div class="col-md-3-body"><p>I'm <strong>Robin Ginn.</strong> In my day job I am a Director of Marketing in the Cloud and Enterprise Group&nbsp;at Microsoft. In the .NET Foundation I give a voice to our people and projects, helping build community support for open source and open standards projects across the industry. I hold the pen.</p></div>
                         </div>
@@ -378,7 +378,7 @@
                             <img class="rounded-image" alt="ProfilePicture" src="https://dnfwebsitewusproduction.blob.core.windows.net/media/Default/_Profiles/a3cd3d28/d0c44402/BethM.jpg?v=636122643340000000">
                             <h4 class="col-md-3-name">Beth Massi</h4>
                             <span>
-                                <a href="https://twitter.com/BethMassi"><i class="fa fa-twitter" aria-hidden="true"></i></a>
+                                <a href="https://twitter.com/BethMassi"><i class="fab fa-twitter" aria-hidden="true"></i></a>
                             </span>
                             <div class="col-md-3-body"><p>I'm&nbsp;<strong>Beth Massi,</strong> Company Secretary&nbsp;for the .NET Foundation and the .NET Product Marketing Manager at Microsoft. I'm focusing on community engagement for the .NET Foundation including the infrastructure to support it.</p></div>
                         </div>


### PR DESCRIPTION
With FontAwesome 5.0, the twitter icon is accessed using
the  class and not the previous . This fixes
the twitter bios of Jon Galloway, Robin Ginn, and Beth Massi.

See https://fontawesome.com/icons/twitter?style=brands

## Before

![image](https://user-images.githubusercontent.com/228256/46264291-0c71aa80-c4e9-11e8-8e1e-e2ceac86b2b1.png)

## After

![image](https://user-images.githubusercontent.com/228256/46264296-1a273000-c4e9-11e8-92db-bedb4fa8615e.png)
