### PR TITLE
Fixed broken "Get started" link

### DIFF
--- a/src/Pages/Index.cshtml
+++ b/src/Pages/Index.cshtml
@@ -190,7 +190,7 @@
                 <p>
                     There&apos;s no time like today to get going. Start your own project, use some code to get traction, and invite fellow coders to bring it to life. It&apos;s more fun with others lending a hand!
                 </p>
-                <a class="site-button site-button--pink" href="#">Get started</a>
+                <a class="site-button site-button--pink" href="/About">Get started</a>
             </div>
             <div class="page-section_column col-md-1 pad-fix--none">
             </div>


### PR DESCRIPTION
"Get started" linked to nothing, now links to "/About" as per Issue #56