### PR TITLE
Use meetup icon and brand color

### DIFF
--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -96,9 +96,9 @@
                         <i class="fab fa-twitter"></i>
                     </a>
                 </div>
-                <div class="site-social_icon site-social_icon--users">
+                <div class="site-social_icon site-social_icon--meetup">
                     <a href="https://www.meetup.com/pro/dotnet/">
-                        <i class="fas fa-users"></i>
+	                    <i class="fab fa-meetup"></i>
                     </a>
                 </div>
             </section>
@@ -166,9 +166,9 @@
                         <i class="fab fa-twitter"></i>
                     </a>
                 </div>
-                <div class="site-social_icon site-social_icon--users">
+                <div class="site-social_icon site-social_icon--meetup">
                     <a href="https://www.meetup.com/pro/dotnet/">
-                        <i class="fas fa-users"></i>
+	                    <i class="fab fa-meetup"></i>
                     </a>
                 </div>
             </section>

--- a/src/wwwroot/css/style.css
+++ b/src/wwwroot/css/style.css
@@ -331,17 +331,17 @@ img {
         transition: all ease .3s;
     }
 
-.site-social_icon--users:hover {
+.site-social_icon--meetup:hover {
     background-color: #68217a;
 }
 
-    .site-social_icon--users:hover svg {
-        fill: #ffffff;
-    }
+	.site-social_icon--meetup:hover svg {
+		fill: #ffffff;
+	}
 
-    .site-social_icon--users:hover .fas:before, .site-social_icon--users:hover .fab:before {
-        color: #ffffff;
-    }
+	.site-social_icon--meetup:hover .fas:before, .site-social_icon--meetup:hover .fab:before {
+		color: #ffffff;
+	}
 
 .site-social_icon--rss:hover {
     background-color: #ef922f;

--- a/src/wwwroot/css/style.css
+++ b/src/wwwroot/css/style.css
@@ -332,7 +332,7 @@ img {
     }
 
 .site-social_icon--meetup:hover {
-    background-color: #68217a;
+	background-color: #e0393e;
 }
 
 	.site-social_icon--meetup:hover svg {


### PR DESCRIPTION
Use the Meetup icon and brand color in the social icons bar instead of a generic users icon.