### PR TITLE
Update projects.json link to use current repo name

### DIFF
--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -30,7 +30,7 @@
   },
   "ProjectFeedConfig": {
     "RepoFeedUrl": "https://dnfrepos.blob.core.windows.net/output/projects_all.json",
-    "ProjectFeedUrl": "https://raw.githubusercontent.com/dotnet/home/master/projects/projects.json",
+    "ProjectFeedUrl": "https://raw.githubusercontent.com/dotnet/foundation/master/projects/projects.json",
     "RepoFeedCacheKey": "projRepoFeed",
     "ProjectFeedCacheKey": "projFeed",
     "CacheDurationInSeconds": "36000"


### PR DESCRIPTION
`dotnet/home` moved to `dotnet/foundation`. 

While GitHub redirects, that can lead to confusion when trying to find the files to change them, as I discovered while examining #65.

This PR updates the reference to the current repo name so that others can easily find it.

Fix can be verified by copying/pasting the URL into a browser.