### PR TITLE
Nav: add membership link to unify across websites

### DIFF
--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -71,6 +71,9 @@
 				<div class="collapse navbar-collapse" id="navbarSupportedContent">
 					<ul id="main-menu" class="navbar-nav ml-auto">
 						<li class="main-menu_item nav-item">
+							<a class="nav-link" href="https://members.dotnetfoundation.org">Membership</a>
+						</li>
+						<li class="main-menu_item nav-item">
 							<a class="nav-link" href="/Get-Involved">Get Involved <span class="sr-only">(current)</span></a>
 						</li>
 						<li class="main-menu_item nav-item">


### PR DESCRIPTION
This unifies nav between https://dotnetfoundation.org/ and https://members.dotnetfoundation.org/ and allows a path back and forth for users.

cc @jongalloway